### PR TITLE
Fixing tuple bug in segment analysis logic

### DIFF
--- a/src/vistiq/segment/analysis.py
+++ b/src/vistiq/segment/analysis.py
@@ -308,7 +308,7 @@ class RegionAnalyzer(StackProcessor):
 
         if spacing is not None:
             # Calculate physical area accounting for pixel spacing
-            pixel_area = np.abs(np.prod(spacing[-2]))
+            pixel_area = np.abs(np.prod(spacing[-2:]))
             return pixel_count * pixel_area
 
         return pixel_count


### PR DESCRIPTION
Resolving quick bug (Line 311, src/vistiq/segment/analysis.py). 

- spacing[-2] selects second to last element as scaler, should instead be a slice of last two elements 
- because of this, any current calculated cross-sectional areas may be overcounted (missing the X scalar)
- only influential when spacing is not None 


